### PR TITLE
Use reader instead of file path.

### DIFF
--- a/cmd/goal/network.go
+++ b/cmd/goal/network.go
@@ -89,14 +89,21 @@ var networkCreateCmd = &cobra.Command{
 			panic(err)
 		}
 
-		var defaultReader io.Reader
+		var templateReader io.Reader
 
 		if networkTemplateFile == "" {
 			if devModeOverride {
-				defaultReader = strings.NewReader(defaultNetworkTemplate)
+				templateReader = strings.NewReader(defaultNetworkTemplate)
 			} else {
-				defaultReader = strings.NewReader(defaultDevNetworkTemplate)
+				templateReader = strings.NewReader(defaultDevNetworkTemplate)
 			}
+		} else {
+			file, err := os.Open(networkTemplateFile)
+			if err != nil {
+				panic(err)
+			}
+			defer file.Close()
+			templateReader = file
 		}
 		if networkTemplateFile != "" {
 			networkTemplateFile, err = filepath.Abs(networkTemplateFile)
@@ -122,7 +129,7 @@ var networkCreateCmd = &cobra.Command{
 			consensus, _ = config.PreloadConfigurableConsensusProtocols(dataDir)
 		}
 
-		network, err := netdeploy.CreateNetworkFromTemplate(networkName, networkRootDir, networkTemplateFile, defaultReader, binDir, !noImportKeys, nil, consensus, devModeOverride)
+		network, err := netdeploy.CreateNetworkFromTemplate(networkName, networkRootDir, templateReader, binDir, !noImportKeys, nil, consensus, devModeOverride)
 		if err != nil {
 			if noClean {
 				reportInfof(" ** failed ** - Preserving network rootdir '%s'", networkRootDir)

--- a/netdeploy/network.go
+++ b/netdeploy/network.go
@@ -58,22 +58,17 @@ type Network struct {
 
 // CreateNetworkFromTemplate uses the specified template to deploy a new private network
 // under the specified root directory.
-func CreateNetworkFromTemplate(name, rootDir, templateFile string, templateReader io.Reader, binDir string, importKeys bool, nodeExitCallback nodecontrol.AlgodExitErrorCallback, consensus config.ConsensusProtocols, overrideDevMode bool) (Network, error) {
+func CreateNetworkFromTemplate(name, rootDir string, templateReader io.Reader, binDir string, importKeys bool, nodeExitCallback nodecontrol.AlgodExitErrorCallback, consensus config.ConsensusProtocols, overrideDevMode bool) (Network, error) {
 	n := Network{
 		rootDir:          rootDir,
 		nodeExitCallback: nodeExitCallback,
 	}
 	n.cfg.Name = name
-	n.cfg.TemplateFile = templateFile
 
 	var err error
 	var template NetworkTemplate
 
-	if templateFile != "" {
-		template, err = loadTemplate(templateFile)
-	} else {
-		err = loadTemplateFromReader(templateReader, &template)
-	}
+	err = loadTemplateFromReader(templateReader, &template)
 
 	if err == nil {
 		if overrideDevMode {


### PR DESCRIPTION
## Summary

It seemed easier to show what I meant rather than try to explain it. Since `*os.File` and `strings.NewReader` implement the same interface you can open the file and pass it in the same way you pass in the default template. It's the same pattern `loadTemplate` / `loadTemplateFromReader` is using.